### PR TITLE
Editar perfil do cliente

### DIFF
--- a/app/controllers/client_profiles_controller.rb
+++ b/app/controllers/client_profiles_controller.rb
@@ -23,6 +23,27 @@ class ClientProfilesController < ApplicationController
     @client_profile = ClientProfile.find(params[:id])
   end
 
+  def edit
+    @client_profile = ClientProfile.find(params[:id])
+
+    unless @client_profile.owner?(current_client)
+      redirect_to root_path, alert: "Você só pode editar o seu #{t(:client_profile, scope: 'activerecord.models')}!"
+    end
+  end
+
+  def update
+    @client_profile = ClientProfile.find(params[:id])
+
+    if !@client_profile.owner?(current_client)
+      redirect_to root_path, alert: "Você só pode editar o seu #{t(:client_profile, scope: 'activerecord.models')}!"
+    elsif @client_profile.update(update_client_profile_params)
+      redirect_to @client_profile, notice: 'Perfil atualizado com sucesso!'
+    else
+      flash[:alert] = "Erro ao atualizar #{t(:client_profile, scope: 'activerecord.models')}!"
+      render :edit
+    end
+  end
+
   private
 
   def client_profile_exists?
@@ -36,6 +57,13 @@ class ClientProfilesController < ApplicationController
   def client_profile_params
     params.require(:client_profile).permit(:full_name, :social_name, :birth_date,
                                            :cpf, :cep, :city, :state, :age_rating,
+                                           :residential_address,
+                                           :residential_number, :photo)
+  end
+
+  def update_client_profile_params
+    params.require(:client_profile).permit(:full_name, :social_name, :birth_date,
+                                           :cep, :city, :state, :age_rating,
                                            :residential_address,
                                            :residential_number, :photo)
   end

--- a/app/controllers/client_profiles_controller.rb
+++ b/app/controllers/client_profiles_controller.rb
@@ -2,6 +2,7 @@ class ClientProfilesController < ApplicationController
   before_action :authenticate_client!, only: %i[create new]
   before_action :authenticate_client_or_admin!, only: %i[show]
   before_action :check_if_profile_is_valid, only: %i[show]
+  before_action :client_is_owner!, only: %i[edit update]
   def create
     @client_profile = current_client.build_client_profile(client_profile_params)
     if client_profile_exists?
@@ -25,18 +26,12 @@ class ClientProfilesController < ApplicationController
 
   def edit
     @client_profile = ClientProfile.find(params[:id])
-
-    unless @client_profile.owner?(current_client)
-      redirect_to root_path, alert: "Você só pode editar o seu #{t(:client_profile, scope: 'activerecord.models')}!"
-    end
   end
 
   def update
     @client_profile = ClientProfile.find(params[:id])
 
-    if !@client_profile.owner?(current_client)
-      redirect_to root_path, alert: "Você só pode editar o seu #{t(:client_profile, scope: 'activerecord.models')}!"
-    elsif @client_profile.update(update_client_profile_params)
+    if @client_profile.update(update_client_profile_params)
       redirect_to @client_profile, notice: 'Perfil atualizado com sucesso!'
     else
       flash[:alert] = "Erro ao atualizar #{t(:client_profile, scope: 'activerecord.models')}!"
@@ -52,6 +47,13 @@ class ClientProfilesController < ApplicationController
 
   def check_if_profile_is_valid
     redirect_to new_client_profile_path unless current_client&.client_profile?
+  end
+
+  def client_is_owner!
+    @client_profile = ClientProfile.find(params[:id])
+    unless @client_profile.owner?(current_client)
+      redirect_to root_path, alert: "Você só pode editar o seu #{t(:client_profile, scope: 'activerecord.models')}!"
+    end
   end
 
   def client_profile_params

--- a/app/models/client_profile.rb
+++ b/app/models/client_profile.rb
@@ -11,6 +11,7 @@ class ClientProfile < ApplicationRecord
 
   def owner?(current_client = nil)
     return current_client == client if current_client
+    false
   end
 
   private

--- a/app/models/client_profile.rb
+++ b/app/models/client_profile.rb
@@ -7,8 +7,11 @@ class ClientProfile < ApplicationRecord
             presence: true
 
   validate :must_include_a_surname, :correct_cpf_length, :correct_cep_length
-
   validate :acceptable_photo
+
+  def owner?(current_client = nil)
+    return current_client == client if current_client
+  end
 
   private
 

--- a/app/models/client_profile.rb
+++ b/app/models/client_profile.rb
@@ -11,6 +11,7 @@ class ClientProfile < ApplicationRecord
 
   def owner?(current_client = nil)
     return current_client == client if current_client
+
     false
   end
 

--- a/app/views/client_profiles/_client_profile.html.erb
+++ b/app/views/client_profiles/_client_profile.html.erb
@@ -1,11 +1,14 @@
-<h2> Perfil de <%= @client_profile.social_name.split.first %> </h2>
+<h2>Perfil de <%= @client_profile.social_name.split.first %></h2>
+<% if @client_profile.owner?(current_client) %>
+  <%= link_to "Editar Perfil", edit_client_profile_path %>
+<% end %>
 
 <dl>
-<% if @client_profile.photo.attached? %>
-    <p><%= image_tag(@client_profile.photo, size: "200x200", alt: 'profile_photo', class: 'profile_photo' )%></p>
-<% else %>
-  <p><%= image_tag("client_photo.svg", size: "200x200", alt: 'profile_photo', class: 'profile_photo') %></p>
-<% end %>
+  <% if @client_profile.photo.attached? %>
+      <p><%= image_tag(@client_profile.photo, size: "200x200", alt: 'profile_photo', class: 'profile_photo' )%></p>
+  <% else %>
+    <p><%= image_tag("client_photo.svg", size: "200x200", alt: 'profile_photo', class: 'profile_photo') %></p>
+  <% end %>
 
   <dt><%= t(:social_name, scope: "activerecord.attributes.client_profile") %>:</dt>
   <dd><%= @client_profile.social_name %></dd>

--- a/app/views/client_profiles/_form.html.erb
+++ b/app/views/client_profiles/_form.html.erb
@@ -1,89 +1,89 @@
 <%= form_with model: @client_profile do |f| %>
+  <div>
+    <%= f.label :full_name %>
+    <%= f.text_field :full_name %>
+    <% @client_profile.errors.full_messages_for(:full_name).each do |message| %>
+      <li><%= message %></li>
+    <% end %>
+  </div>
 
-<div>
-  <%= f.label :full_name %>
-  <%= f.text_field :full_name %>
-  <% @client_profile.errors.full_messages_for(:full_name).each do |message| %>
-    <li><%= message %></li>
-  <% end %>
-</div>
+  <div>
+    <%= f.label :social_name %>
+    <%= f.text_field :social_name %>
+    <% @client_profile.errors.full_messages_for(:social_name).each do |message| %>
+      <li><%= message %></li>
+    <% end %>
+  </div>
 
-<div>
-  <%= f.label :social_name %>
-  <%= f.text_field :social_name %>
-  <% @client_profile.errors.full_messages_for(:social_name).each do |message| %>
-    <li><%= message %></li>
-  <% end %>
-</div>
+  <div>
+    <%= f.label :birth_date %>
+    <%= f.date_field :birth_date %>
+    <% @client_profile.errors.full_messages_for(:birth_date).each do |message| %>
+      <li><%= message %></li>
+    <% end %>
+  </div>
 
-<div>
-  <%= f.label :birth_date %>
-  <%= f.date_field :birth_date %>
-  <% @client_profile.errors.full_messages_for(:birth_date).each do |message| %>
-    <li><%= message %></li>
-  <% end %>
-</div>
+  <div>
+    <%= f.label :cpf, 'CPF (apenas números)' %>
+    <%= f.number_field :cpf if current_page?(new_client_profile_path) %>
+    <%= @client_profile.cpf if !current_page?(new_client_profile_path) %>
+    <% @client_profile.errors.full_messages_for(:cpf).each do |message| %>
+      <li><%= message %></li>
+    <% end %>
+  </div>
 
-<div>
-  <%= f.label :cpf, 'CPF (apenas números)' %>
-  <%= f.number_field :cpf %>
-  <% @client_profile.errors.full_messages_for(:cpf).each do |message| %>
-    <li><%= message %></li>
-  <% end %>
-</div>
+  <div>
+    <%= f.label :cep %>
+    <%= f.number_field :cep %>
+    <% @client_profile.errors.full_messages_for(:cep).each do |message| %>
+      <li><%= message %></li>
+    <% end %>
+  </div>
 
-<div>
-  <%= f.label :cep %>
-  <%= f.number_field :cep %>
-  <% @client_profile.errors.full_messages_for(:cep).each do |message| %>
-    <li><%= message %></li>
-  <% end %>
-</div>
+  <div>
+    <%= f.label :residential_address %>
+    <%= f.text_field :residential_address %>
+    <% @client_profile.errors.full_messages_for(:residential_address).each do |message| %>
+      <li><%= message %></li>
+    <% end %>
+  </div>
 
-<div>
-  <%= f.label :residential_address %>
-  <%= f.text_field :residential_address %>
-  <% @client_profile.errors.full_messages_for(:residential_address).each do |message| %>
-    <li><%= message %></li>
-  <% end %>
-</div>
+  <div>
+    <%= f.label :residential_number %>
+    <%= f.number_field :residential_number%>
+    <% @client_profile.errors.full_messages_for(:residential_number).each do |message| %>
+      <li><%= message %></li>
+    <% end %>
+  </div>
 
-<div>
-  <%= f.label :residential_number %>
-  <%= f.number_field :residential_number%>
-  <% @client_profile.errors.full_messages_for(:residential_number).each do |message| %>
-    <li><%= message %></li>
-  <% end %>
-</div>
+  <div>
+    <%= f.label :city %>
+    <%= f.text_field :city %>
+    <% @client_profile.errors.full_messages_for(:city).each do |message| %>
+      <li><%= message %></li>
+    <% end %>
+  </div>
 
-<div>
-  <%= f.label :city %>
-  <%= f.text_field :city %>
-  <% @client_profile.errors.full_messages_for(:city).each do |message| %>
-    <li><%= message %></li>
-  <% end %>
-</div>
+  <div>
+    <%= f.label :state %>
+    <%= f.text_field :state %>
+    <% @client_profile.errors.full_messages_for(:state).each do |message| %>
+      <li><%= message %></li>
+    <% end %>
+  </div>
 
-<div>
-  <%= f.label :state %>
-  <%= f.text_field :state %>
-  <% @client_profile.errors.full_messages_for(:state).each do |message| %>
-    <li><%= message %></li>
-  <% end %>
-</div>
+  <div>
+    <%= f.label :age_rating%>
+    <%= f.select :age_rating, ['L', '10', '12', '14', '16', '18'] %>
+    <% @client_profile.errors.full_messages_for(:age_rating).each do |message| %>
+      <li><%= message %></li>
+    <% end %>
+  </div>
 
-<div>
-  <%= f.label :age_rating%>
-  <%= f.select :age_rating, ['L', '10', '12', '14', '16', '18'] %>
-  <% @client_profile.errors.full_messages_for(:age_rating).each do |message| %>
-    <li><%= message %></li>
-  <% end %>
-</div>
-
-<div>
-  <%= f.label :photo %>
-  <%= f.file_field :photo %>
-</div>
+  <div>
+    <%= f.label :photo %>
+    <%= f.file_field :photo %>
+  </div>
 
   <%= f.submit %>
 <% end %>

--- a/app/views/client_profiles/edit.html.erb
+++ b/app/views/client_profiles/edit.html.erb
@@ -1,0 +1,2 @@
+<h1>Insira as informações que deseja atualizar!</h1>
+<%= render "client_profiles/form", object: @client_profile %>

--- a/app/views/streamer_profiles/_form.html.erb
+++ b/app/views/streamer_profiles/_form.html.erb
@@ -50,5 +50,4 @@
   <div>
     <%= f.submit %>
   </div>
-
 <% end %>

--- a/app/views/streamer_profiles/_streamer_profile.html.erb
+++ b/app/views/streamer_profiles/_streamer_profile.html.erb
@@ -1,15 +1,15 @@
-<% if @streamer_profile.photo.attached? %>
-    <p><%= image_tag(@streamer_profile.photo, size: "200x200", alt: 'profile_photo', class: 'profile_photo' )%></p>
-<% else %>
-  <p><%= image_tag("streamer_photo.svg", size: "200x200", alt: 'profile_photo', class: 'profile_photo') %></p>
-<% end %>
-
 <h2>Perfil de <%= @streamer_profile.name %></h2>
 <% if @streamer_profile.owner?(current_streamer) %>
   <%= link_to "Editar Perfil", edit_streamer_profile_path %>
 <% end %>
 
 <dl>
+  <% if @streamer_profile.photo.attached? %>
+    <p><%= image_tag(@streamer_profile.photo, size: "200x200", alt: 'profile_photo', class: 'profile_photo' )%></p>
+  <% else %>
+    <p><%= image_tag("streamer_photo.svg", size: "200x200", alt: 'profile_photo', class: 'profile_photo') %></p>
+  <% end %>
+
   <dt><%= t(:description, scope: "activerecord.attributes.streamer_profile") %>:</dt>
   <dd><%= @streamer_profile.description %></dd>
 

--- a/app/views/videos/_form.html.erb
+++ b/app/views/videos/_form.html.erb
@@ -7,7 +7,6 @@
 <% end %>  
 
 <%= form_with model: @video do |video|%>
-
   <%= video.label :name %>
   <%= video.text_field :name %><br>
 

--- a/app/views/videos/_video.html.erb
+++ b/app/views/videos/_video.html.erb
@@ -1,8 +1,8 @@
 <dl>
-  <dt><%= Video.human_attribute_name(:name) %>: </dt>
+  <dt><%= Video.human_attribute_name(:name) %>:</dt>
   <dd><%= @video.name %></dd>
 
-  <dt><%= Video.human_attribute_name(:description) %>: </dt>
+  <dt><%= Video.human_attribute_name(:description) %>:</dt>
   <dd> <%= @video.description %> </dd>
 
   <%= link_to Video.human_attribute_name(:video), @video.link %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
     get 'admin_area', on: :collection
   end
 
-  resources :client_profiles, only: %i[create new show]
+  resources :client_profiles, only: %i[create new show edit update]
   resources :streamer_profiles, only: %i[show new create edit update]
   resources :game_categories, only: %i[create new]
   resources :videos, only: %i[new create show]

--- a/spec/system/client_profile_spec.rb
+++ b/spec/system/client_profile_spec.rb
@@ -44,7 +44,7 @@ describe 'Client profile' do
       click_on 'Criar Perfil de usuário'
 
       expect(current_path).to eq client_profiles_path
-      expect(page).to have_content('Erro ao criar Perfil de usuário!') 
+      expect(page).to have_content('Erro ao criar Perfil de usuário!')
       expect(page).to have_content(
         'Nome completo (conforme documentos) não pode ficar em branco'
       )

--- a/spec/system/client_profile_spec.rb
+++ b/spec/system/client_profile_spec.rb
@@ -31,6 +31,7 @@ describe 'Client profile' do
       expect(page).to have_content('Cidade: São Paulo, SP')
       expect(ClientProfile.count).to eq(1)
       expect(page).to have_css("img[src*='gary-bendig-unsplash.jpg']")
+      expect(page).to_not have_content('CPF: 60243105878')
     end
     it 'unsuccessfully: left mandatory information blank' do
       client = create(:client)
@@ -42,6 +43,8 @@ describe 'Client profile' do
       click_on 'Entrar'
       click_on 'Criar Perfil de usuário'
 
+      expect(current_path).to eq client_profiles_path
+      expect(page).to have_content('Erro ao criar Perfil de usuário!') 
       expect(page).to have_content(
         'Nome completo (conforme documentos) não pode ficar em branco'
       )
@@ -58,14 +61,105 @@ describe 'Client profile' do
       create(:client_profile, client: client)
 
       visit root_path
-      click_on 'Entrar como Assinante'
-      fill_in 'Email', with: client.email
-      fill_in 'Senha', with: client.password
-      click_on 'Entrar'
+      login_as client, scope: :client
       visit new_client_profile_path
 
       expect(current_path).to eq client_profile_path(client.client_profile.id)
       expect(page).to have_content('Perfil já existente!')
+    end
+    it 'successfully: click on the link to edit profile' do
+      client = create(:client)
+      profile = create(:client_profile, client: client)
+
+      login_as client, scope: :client
+      visit root_path
+      click_on 'Meu Perfil'
+      click_on 'Editar Perfil'
+
+      expect(current_path).to eq edit_client_profile_path(profile)
+      expect(page).to have_content('Insira as informações que deseja atualizar!')
+      expect(page).to have_content('CPF (apenas números) 80052514080')
+    end
+    it 'successfully: edit profile' do
+      client = create(:client)
+      create(:client_profile, :with_photo, client: client)
+
+      login_as client, scope: :client
+      visit root_path
+      click_on 'Meu Perfil'
+      click_on 'Editar Perfil'
+      fill_in 'Nome completo (conforme documentos)', with: 'Plínio Larrubia Ferreira de Moura'
+      fill_in 'Nome social', with: 'Mario'
+      fill_in 'Data de nascimento', with: '22/06/1999'
+      fill_in 'CEP', with: '28400000'
+      fill_in 'Cidade', with: 'São Fidélis'
+      fill_in 'Estado', with: 'RJ'
+      fill_in 'Endereço residencial', with: 'Rua Santa Cecília'
+      fill_in 'Número residencial', with: '61'
+      select '18', from: 'Configuração de classificação etária'
+      click_on 'Atualizar Perfil de usuário'
+
+      expect(current_path).to eq client_profile_path(client.client_profile)
+      expect(page).to have_content('Perfil atualizado com sucesso!')
+      expect(page).to have_content('Perfil de Mario')
+      expect(page).to have_content('Data de nascimento: 22/06/1999')
+      expect(page).to have_content('Configuração de classificação etária: 18')
+      expect(page).to have_content('Endereço residencial: Rua Santa Cecília, número 61')
+      expect(page).to have_content('CEP: 28400000')
+      expect(page).to have_content('Cidade: São Fidélis, RJ')
+      expect(page).to have_css("img[src*='gary-bendig-unsplash.jpg']")
+    end
+    it 'unsuccessfully: cant edit another client profile' do
+      client = create(:client)
+      client2 = create(:client)
+      create(:client_profile, client: client)
+      client_profile2 = create(:client_profile, client: client2)
+
+      login_as client, scope: :client
+      visit root_path
+      visit edit_client_profile_path(client2.client_profile)
+
+      expect(current_path).to eq root_path
+      expect(page).to have_content 'Você só pode editar o seu ' \
+                                   "#{I18n.t(:client_profile, scope: 'activerecord.models')}!"
+      expect(page).to_not have_content(client_profile2.social_name)
+      expect(page).to_not have_content(I18n.l(client_profile2.birth_date))
+      expect(page).to_not have_content(client_profile2.cpf)
+      expect(page).to_not have_content(client_profile2.cep)
+      expect(page).to_not have_content(client_profile2.city)
+      expect(page).to_not have_content(client_profile2.state)
+      expect(page).to_not have_content(client_profile2.residential_number)
+      expect(page).to_not have_content(client_profile2.residential_address)
+      expect(page).to_not have_content(client_profile2.age_rating)
+    end
+
+    it 'unsuccessfully edit filling fields wrong' do
+      client = create(:client)
+      create(:client_profile, client: client)
+
+      login_as client, scope: :client
+      visit root_path
+      click_on 'Meu Perfil'
+      click_on 'Editar Perfil'
+      fill_in 'Nome completo (conforme documentos)', with: ''
+      fill_in 'Nome social', with: ''
+      fill_in 'Data de nascimento', with: ''
+      fill_in 'CEP', with: ''
+      fill_in 'Cidade', with: ''
+      fill_in 'Estado', with: ''
+      fill_in 'Endereço residencial', with: ''
+      fill_in 'Número residencial', with: ''
+      select '18', from: 'Configuração de classificação etária'
+      click_on 'Atualizar Perfil de usuário'
+
+      expect(current_path).to eq client_profile_path(client.client_profile)
+      expect(page).to have_content('Erro ao atualizar Perfil de usuário!')
+      expect(page).to have_content('Data de nascimento não pode ficar em branco')
+      expect(page).to have_content('Endereço residencial não pode ficar em branco')
+      expect(page).to have_content('Número residencial não pode ficar em branco')
+      expect(page).to have_content('CEP não pode ficar em branco')
+      expect(page).to have_content('Cidade não pode ficar em branco')
+      expect(page).to have_content('Estado não pode ficar em branco')
     end
   end
   context 'Visualization:' do

--- a/spec/system/streamer_profile_spec.rb
+++ b/spec/system/streamer_profile_spec.rb
@@ -44,6 +44,7 @@ describe 'Streamer log in' do
       click_on 'Criar Perfil de streamer'
 
       expect(current_path).to eq streamer_profiles_path
+      expect(page).to have_content('Erro ao criar Perfil de streamer!')
       expect(page).to have_content('Nome não pode ficar em branco')
       expect(page).to have_content('Descrição não pode ficar em branco')
     end
@@ -53,11 +54,8 @@ describe 'Streamer log in' do
       streamer = create(:streamer)
       create(:streamer_profile, streamer: streamer)
 
+      login_as streamer, scope: :streamer
       visit root_path
-      click_on 'Entrar como Streamer'
-      fill_in 'Email', with: streamer.email
-      fill_in 'Senha', with: streamer.password
-      click_on 'Entrar'
       visit new_streamer_profile_path
 
       expect(current_path).to eq streamer_profile_path(streamer.streamer_profile.id)
@@ -68,11 +66,8 @@ describe 'Streamer log in' do
       streamer = create(:streamer)
       profile = create(:streamer_profile, streamer: streamer)
 
+      login_as streamer, scope: :streamer
       visit root_path
-      click_on 'Entrar como Streamer'
-      fill_in 'Email', with: streamer.email
-      fill_in 'Senha', with: streamer.password
-      click_on 'Entrar'
       click_on 'Meu Perfil'
       click_on 'Editar Perfil'
 
@@ -84,11 +79,8 @@ describe 'Streamer log in' do
       streamer = create(:streamer)
       create(:streamer_profile, streamer: streamer)
 
+      login_as streamer, scope: :streamer
       visit root_path
-      click_on 'Entrar como Streamer'
-      fill_in 'Email', with: streamer.email
-      fill_in 'Senha', with: streamer.password
-      click_on 'Entrar'
       click_on 'Meu Perfil'
       click_on 'Editar Perfil'
       fill_in 'Descrição', with: 'Faço gameplays maneiras'
@@ -101,17 +93,35 @@ describe 'Streamer log in' do
                                '-7cf2b2e4a6bf46ca28b45bc3a866a1a9bfca0a3de9ce12f59caf7da72bcf72b8.svg"]')
     end
 
+    it 'and edit filling fields wrong' do
+      streamer = create(:streamer)
+      create(:streamer_profile, streamer: streamer)
+
+      login_as streamer, scope: :streamer
+      visit root_path
+      click_on 'Meu Perfil'
+      click_on 'Editar Perfil'
+      fill_in 'Nome', with: ''
+      fill_in 'Descrição', with: ''
+      fill_in 'URL do Facebook', with: ''
+      fill_in 'URL do Instagram', with: ''
+      fill_in 'URL do Twitter', with: ''
+      click_on 'Atualizar Perfil de streamer'
+
+      expect(current_path).to eq streamer_profile_path(streamer.streamer_profile)
+      expect(page).to have_content('Erro ao atualizar Perfil de streamer!')
+      expect(page).to have_content('Nome não pode ficar em branco')
+      expect(page).to have_content('Descrição não pode ficar em branco')
+    end
+
     it 'and cant edit another streamer profile' do
       streamer = create(:streamer)
       streamer2 = create(:streamer)
       create(:streamer_profile, streamer: streamer)
       streamer_profile2 = create(:streamer_profile, streamer: streamer2)
 
+      login_as streamer, scope: :streamer
       visit root_path
-      click_on 'Entrar como Streamer'
-      fill_in 'Email', with: streamer.email
-      fill_in 'Senha', with: streamer.password
-      click_on 'Entrar'
       visit edit_streamer_profile_path(streamer2.streamer_profile)
 
       expect(current_path).to eq root_path


### PR DESCRIPTION
- Mais testes para verificar edição de perfis
- Padronização das views de cada perfil
- Método `owner?` para `client_profile`
- Cliente pode editar tudo, _exceto CPF_
- Ajustar `indentação` de algumas views

Resolve: #85