### PR TITLE
Adiciona configuração do GH Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,57 @@
+name: Rails Pipeline
+
+env:
+  RUBY_VERSION: 3.0.2
+  NODE_VERSION: 12.18.1
+  BUNDLER_VERSION: 2.2.22
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  workflow:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup System
+        run: sudo apt-get install -y libsqlite3-dev
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+         ruby-version: ${{ env.RUBY_VERSION }}
+  
+      - name: Bundle install
+        run: |
+          gem uninstall -aIx bundler
+          gem install bundler -v ${{ env.BUNDLER_VERSION }}
+          bundle config path vendor/bundle
+          bundle install --jobs 4 --retry 3
+
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Yarn Install
+        run: bin/yarn
+      
+      - name: Rspec
+        run: |
+          bundle exec rails db:prepare
+          bundle exec rspec
+          
+      - name: Rubocop
+        run: bundle exec rubocop -c .rubocop.yml
+      
+      - name: Audit
+        run: |
+          gem install bundler-audit
+          bundle-audit --update


### PR DESCRIPTION
## Motivação

Nesse pull request estamos ligando o GitHub Action para rodar `rspec`, `rubocop` e `bundler-audit`.

Assim verificando se os Pull Requests estão de acordo com os requisitos para entrar na master

## Comentários

O [bundler-audit](https://github.com/rubysec/bundler-audit) é uma gem que verifica falhas de segurança nas gems do nosso Gemfile, assim mantendo nossa aplicação segura. O GitHub também usa o DependaBot para esse fim mas aqui é uma ferramenta que quebra o CI caso isso aconteça, para que nenhum branch vá para a `master` com falhas de segurança.

## Links úteis

- [Integração continua](https://en.wikipedia.org/wiki/Continuous_integration)
- [Documentação](https://help.github.com/en/actions)