### PR TITLE
corregindo typo erro em company token, requisição api

### DIFF
--- a/app/models/client_profile.rb
+++ b/app/models/client_profile.rb
@@ -53,6 +53,6 @@ class ClientProfile < ApplicationRecord
   def faraday_call(current_client)
     Faraday.post('http://localhost:4000/api/v1/customers',
                  { name: current_client.client_profile.full_name, cpf: current_client.client_profile.cpf },
-                 { company_token: Rails.configuration.payment_api['company_auth_token'] })
+                 { companyToken: Rails.configuration.payment_api['company_auth_token'] })
   end
 end

--- a/app/models/payment_method.rb
+++ b/app/models/payment_method.rb
@@ -9,7 +9,7 @@ class PaymentMethod
   def self.all
     result = []
     response = Faraday.get('http://pagapaga.com.br/api/v1/payment_methods/', nil,
-                           { company_token: SecureRandom.alphanumeric(20) })
+                           { companyToken: SecureRandom.alphanumeric(20) })
     return if response.status == 500
 
     if response.status == 200

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -12,7 +12,7 @@ class Plan < ApplicationRecord
   def register_plan_api(plan)
     response = Faraday.post('http://localhost:4000/api/v1/products',
                             { product: { name: plan.name, type_of: 'subscription', status: 'enabled' } },
-                            { company_token: Rails.configuration.payment_api['company_auth_token'] })
+                            { companyToken: Rails.configuration.payment_api['company_auth_token'] })
     case response.status
     when 201
       plan.plan_token = JSON.parse(response.body, simbolize_names: true)['token']

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -19,7 +19,7 @@ class Video < ApplicationRecord
   def register_video_api(video)
     response = Faraday.post('http://localhost:4000/api/v1/products',
                             { product: { name: video.name, type_of: 'single' } },
-                            { company_token: Rails.configuration.payment_api['company_auth_token'] })
+                            { companyToken: Rails.configuration.payment_api['company_auth_token'] })
     case response.status
     when 500, 422
       video.single_video_token = nil

--- a/spec/models/client_profile_spec.rb
+++ b/spec/models/client_profile_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe ClientProfile, type: :model do
       fake_response = double('faraday_response', status: 201, body: api_response)
       allow(Faraday).to receive(:post).with('http://localhost:4000/api/v1/customers',
                                             { name: client_profile.full_name, cpf: client_profile.cpf },
-                                            { company_token: Rails.configuration.payment_api['company_auth_token'] })
+                                            { companyToken: Rails.configuration.payment_api['company_auth_token'] })
                                       .and_return(fake_response)
 
       client_profile.register_client_api(client_profile.client)
@@ -77,7 +77,7 @@ RSpec.describe ClientProfile, type: :model do
       fake_response = double('faraday_response', status: 422, body: api_response)
       allow(Faraday).to receive(:post).with('http://localhost:4000/api/v1/customers',
                                             any_args,
-                                            { company_token: Rails.configuration.payment_api['company_auth_token'] })
+                                            { companyToken: Rails.configuration.payment_api['company_auth_token'] })
                                       .and_return(fake_response)
       client_profile.register_client_api(client_profile.client)
 
@@ -90,7 +90,7 @@ RSpec.describe ClientProfile, type: :model do
       fake_response = double('faraday_response', status: 500, body: '')
       allow(Faraday).to receive(:post).with('http://localhost:4000/api/v1/customers',
                                             { name: client_profile.full_name, cpf: client_profile.cpf },
-                                            { company_token: Rails.configuration.payment_api['company_auth_token'] })
+                                            { companyToken: Rails.configuration.payment_api['company_auth_token'] })
                                       .and_return(fake_response)
       client_profile.register_client_api(client_profile.client)
 

--- a/spec/models/payment_method_spec.rb
+++ b/spec/models/payment_method_spec.rb
@@ -7,7 +7,7 @@ describe PaymentMethod, type: :model do
       fake_response = double('faraday_response', status: 200, body: api_response)
       allow(SecureRandom).to receive(:alphanumeric).with(20).and_return('154689459647851263as')
       allow(Faraday).to receive(:get).with('http://pagapaga.com.br/api/v1/payment_methods/', nil,
-                                           { company_token: '154689459647851263as' })
+                                           { companyToken: '154689459647851263as' })
                                      .and_return(fake_response)
 
       result = PaymentMethod.all
@@ -26,7 +26,7 @@ describe PaymentMethod, type: :model do
 
       allow(SecureRandom).to receive(:alphanumeric).with(20).and_return('154689459647851263as')
       allow(Faraday).to receive(:get).with('http://pagapaga.com.br/api/v1/payment_methods/', nil,
-                                           { company_token: '154689459647851263as' })
+                                           { companyToken: '154689459647851263as' })
                                      .and_return(fake_response)
 
       result = PaymentMethod.all

--- a/spec/models/plan_spec.rb
+++ b/spec/models/plan_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Plan, type: :model do
         allow(Faraday).to receive(:post).with('http://localhost:4000/api/v1/products',
                                               { product: { name: plan.name, type_of: 'subscription',
                                                            status: 'enabled' } },
-                                              { company_token: Rails.configuration.payment_api['company_auth_token'] })
+                                              { companyToken: Rails.configuration.payment_api['company_auth_token'] })
                                         .and_return(fake_response)
         plan.register_plan_api(plan)
 
@@ -35,7 +35,7 @@ RSpec.describe Plan, type: :model do
         allow(Faraday).to receive(:post).with('http://localhost:4000/api/v1/products',
                                               { product: { name: plan.name, type_of: 'subscription',
                                                            status: 'enabled' } },
-                                              { company_token: Rails.configuration.payment_api['company_auth_token'] })
+                                              { companyToken: Rails.configuration.payment_api['company_auth_token'] })
                                         .and_return(fake_response)
         plan.register_plan_api(plan)
 
@@ -51,7 +51,7 @@ RSpec.describe Plan, type: :model do
         allow(Faraday).to receive(:post).with('http://localhost:4000/api/v1/products',
                                               { product: { name: plan.name, type_of: 'subscription',
                                                            status: 'enabled' } },
-                                              { company_token: Rails.configuration.payment_api['company_auth_token'] })
+                                              { companyToken: Rails.configuration.payment_api['company_auth_token'] })
                                         .and_return(fake_response)
 
         plan.register_plan_api(plan)

--- a/spec/models/video_spec.rb
+++ b/spec/models/video_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Video, type: :model do
         fake_response = double('faraday_response', status: 201, body: api_response)
         allow(Faraday).to receive(:post).with('http://localhost:4000/api/v1/products',
                                               { product: { name: video.name, type_of: 'single' } },
-                                              { company_token: Rails.configuration.payment_api['company_auth_token'] })
+                                              { companyToken: Rails.configuration.payment_api['company_auth_token'] })
                                         .and_return(fake_response)
 
         video.register_video_api(video)
@@ -77,7 +77,7 @@ RSpec.describe Video, type: :model do
         fake_response = double('faraday_response', status: 422, body: api_response)
         allow(Faraday).to receive(:post).with('http://localhost:4000/api/v1/products',
                                               any_args,
-                                              { company_token: Rails.configuration.payment_api['company_auth_token'] })
+                                              { companyToken: Rails.configuration.payment_api['company_auth_token'] })
                                         .and_return(fake_response)
         video.register_video_api(video)
 
@@ -91,7 +91,7 @@ RSpec.describe Video, type: :model do
         fake_response = double('faraday_response', status: 500, body: nil)
         allow(Faraday).to receive(:post).with('http://localhost:4000/api/v1/products',
                                               { product: { name: video.name, type_of: 'single' } },
-                                              { company_token: Rails.configuration.payment_api['company_auth_token'] })
+                                              { companyToken: Rails.configuration.payment_api['company_auth_token'] })
                                         .and_return(fake_response)
 
         video.register_video_api(video)

--- a/spec/system/admin_evaluate_registration_of_video_spec.rb
+++ b/spec/system/admin_evaluate_registration_of_video_spec.rb
@@ -55,7 +55,7 @@ describe 'admin approves registration of video' do
     fake_response = double('faraday_response', status: 201, body: api_response)
     allow(Faraday).to receive(:post).with('http://localhost:4000/api/v1/products',
                                           { product: { name: video.name, type_of: 'single' } },
-                                          { company_token: Rails.configuration.payment_api['company_auth_token'] })
+                                          { companyToken: Rails.configuration.payment_api['company_auth_token'] })
                                     .and_return(fake_response)
 
     login_as admin, scope: :admin
@@ -80,7 +80,7 @@ describe 'admin approves registration of video' do
     fake_response = double('faraday_response', status: 500, body: nil)
     allow(Faraday).to receive(:post).with('http://localhost:4000/api/v1/products',
                                           { product: { name: video.name, type_of: 'single' } },
-                                          { company_token: Rails.configuration.payment_api['company_auth_token'] })
+                                          { companyToken: Rails.configuration.payment_api['company_auth_token'] })
                                     .and_return(fake_response)
 
     login_as admin, scope: :admin

--- a/spec/system/admin_register_plan_spec.rb
+++ b/spec/system/admin_register_plan_spec.rb
@@ -43,7 +43,7 @@ describe 'Some' do
       allow(Faraday).to receive(:post).with('http://localhost:4000/api/v1/products',
                                             { product: { name: 'Plano Gamer', type_of: 'subscription',
                                                          status: 'enabled' } },
-                                            { company_token: Rails.configuration.payment_api['company_auth_token'] })
+                                            { companyToken: Rails.configuration.payment_api['company_auth_token'] })
                                       .and_return(fake_response)
 
       login_as admin, scope: :admin
@@ -121,7 +121,7 @@ describe 'Some' do
       allow(Faraday).to receive(:post).with('http://localhost:4000/api/v1/products',
                                             { product: { name: 'Plano 4', type_of: 'subscription',
                                                          status: 'enabled' } },
-                                            { company_token: Rails.configuration.payment_api['company_auth_token'] })
+                                            { companyToken: Rails.configuration.payment_api['company_auth_token'] })
                                       .and_return(fake_response)
 
       login_as admin, scope: :admin
@@ -150,7 +150,7 @@ describe 'Some' do
       allow(Faraday).to receive(:post).with('http://localhost:4000/api/v1/products',
                                             { product: { name: 'Plano 4', type_of: 'subscription',
                                                          status: 'enabled' } },
-                                            { company_token: Rails.configuration.payment_api['company_auth_token'] })
+                                            { companyToken: Rails.configuration.payment_api['company_auth_token'] })
                                       .and_return(fake_response)
 
       login_as admin, scope: :admin
@@ -180,7 +180,7 @@ describe 'Some' do
       allow(Faraday).to receive(:post).with('http://localhost:4000/api/v1/products',
                                             { product: { name: 'Plano 4', type_of: 'subscription',
                                                          status: 'enabled' } },
-                                            { company_token: Rails.configuration.payment_api['company_auth_token'] })
+                                            { companyToken: Rails.configuration.payment_api['company_auth_token'] })
                                       .and_return(fake_response)
 
       login_as admin, scope: :admin

--- a/spec/system/client_profile_spec.rb
+++ b/spec/system/client_profile_spec.rb
@@ -8,7 +8,7 @@ describe 'Client profile' do
       fake_response = double('faraday_response', status: 201, body: api_response)
       allow(Faraday).to receive(:post).with('http://localhost:4000/api/v1/customers',
                                             { name: 'Otávio Augusto da Silva Lins', cpf: '60243105878' },
-                                            { company_token: Rails.configuration.payment_api['company_auth_token'] })
+                                            { companyToken: Rails.configuration.payment_api['company_auth_token'] })
                                       .and_return(fake_response)
 
       visit root_path

--- a/spec/system/payment_methods_registration_spec.rb
+++ b/spec/system/payment_methods_registration_spec.rb
@@ -8,7 +8,7 @@ describe 'Payment methods registration' do
       fake_response = double('faraday_response', status: 500, body: '')
       allow(Faraday).to receive(:post).with('http://localhost:4000/api/v1/customers',
                                             { name: client.client_profile.full_name, cpf: client.client_profile.cpf },
-                                            { company_token: Rails.configuration.payment_api['company_auth_token'] })
+                                            { companyToken: Rails.configuration.payment_api['company_auth_token'] })
                                       .and_return(fake_response)
 
       login_as client, scope: :client


### PR DESCRIPTION
Typo erro que impedia autenticação de empresa via api.
- Em produtos video e plano